### PR TITLE
Make embarrass command ratelimit-friendly

### DIFF
--- a/cmds/embarrass.js
+++ b/cmds/embarrass.js
@@ -1,6 +1,8 @@
 'use strict';
 
 let lists = require('../functions/lists');
+let getOrCreateWebhoook = require('../functions/getOrCreateWebhook');
+
 
 module.exports = {
   name: 'embarrass',
@@ -32,31 +34,13 @@ module.exports = {
       ) {
         msg.channel.createMessage(`<@${user.id}> ${embarrassingThing}`);
       } else {
-        msg.channel.getWebhooks().then(
-          thing => {
-            if (
-              !thing.length ||
-              !thing.find(t => t.type === 1)
-            ) {
-              msg.channel.createWebhook({ name: 'Dad bot' }).then(
-                webhook => {
-                  client
-                    .executeWebhook(webhook.id, webhook.token, {
-                      content: embarrassingThing,
-                      username: user.nick || user.username,
-                      avatarURL
-                    }).catch(() => {});
-                }
-              ).catch(() => {});
-            } else {
-              const webhook = thing.find(wh => wh.type === 1);
-              client
-                .executeWebhook(webhook.id, webhook.token, {
-                  content: embarrassingThing,
-                  username: user.nick || user.username,
-                  avatarURL
-                }).catch(() => {});
-            }
+        getOrCreateWebhoook(client, msg).then(
+          webhook => {
+            client.executeWebhook(webhook.id, webhook.token, {
+              content: embarrassingThing,
+              username: user.nick || user.username,
+              avatarURL
+            }).catch(() => {});
           }
         ).catch(() => {});
       }

--- a/cmds/embarrass.js
+++ b/cmds/embarrass.js
@@ -32,23 +32,33 @@ module.exports = {
       ) {
         msg.channel.createMessage(`<@${user.id}> ${embarrassingThing}`);
       } else {
-        msg.channel.createWebhook({ name: user.username }).then(
+        msg.channel.getWebhooks().then(
           thing => {
-            setTimeout(() => {
+            if (
+              !thing.length ||
+              !thing.find(t => t.type === 1)
+            ) {
+              msg.channel.createWebhook({ name: 'Dad bot' }).then(
+                webhook => {
+                  client
+                    .executeWebhook(webhook.id, webhook.token, {
+                      content: embarrassingThing,
+                      username: user.nick || user.username,
+                      avatarURL
+                    }).catch(() => {});
+                }
+              ).catch(() => {});
+            } else {
+              const webhook = thing.find(wh => wh.type === 1);
               client
-                .executeWebhook(thing.id, thing.token, {
+                .executeWebhook(webhook.id, webhook.token, {
                   content: embarrassingThing,
-                  avatarURL: avatarURL,
-                  username: user.nick ? user.nick : user.username
-                })
-                .catch(() => {});
-              setTimeout(() => {
-                client.deleteWebhook(thing.id);
-              }, 5000);
-            }, 100);
-          },
-          () => {}
-        );
+                  username: user.nick || user.username,
+                  avatarURL
+                }).catch(() => {});
+            }
+          }
+        ).catch(() => {});
       }
     } else
       msg.channel.createMessage(

--- a/cmds/misspelledembarrass.js
+++ b/cmds/misspelledembarrass.js
@@ -1,5 +1,7 @@
 'use strict';
 
+let getOrCreateWebhoook = require('../functions/getOrCreateWebhook');
+
 module.exports = {
   name: 'embarass',
 
@@ -9,31 +11,14 @@ module.exports = {
         .get(user.id)
         .dynamicAvatarURL('png', 2048)
         .split('?')[0];
-    msg.channel.getWebhooks().then(
-      thing => {
-        if (
-          !thing.length ||
-          !thing.find(t => t.type === 1)
-        ) {
-          msg.channel.createWebhook({ name: 'Dad bot' }).then(
-            webhook => {
-              client
-                .executeWebhook(webhook.id, webhook.token, {
-                  content: `I don't know how to spell \`embarrass\` properly.`,
-                  username: user.nick || user.username,
-                  avatarURL
-                }).catch(() => {});
-            }
-          ).catch(() => {});
-        } else {
-          const webhook = thing.find(wh => wh.type === 1);
-          client
-            .executeWebhook(webhook.id, webhook.token, {
-              content: `I don't know how to spell \`embarrass\` properly.`,
-              username: user.nick || user.username,
-              avatarURL
-            }).catch(() => {});
-        }
+
+    getOrCreateWebhoook(client, msg).then(
+      webhook => {
+        client.executeWebhook(webhook.id, webhook.token, {
+          content: "I don't know how to spell `embarrass` properly.",
+          username: user.nick || user.username,
+          avatarURL
+        }).catch(() => {});
       }
     ).catch(() => {});
   },

--- a/cmds/misspelledembarrass.js
+++ b/cmds/misspelledembarrass.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'embarass',
+  name: 'aem',
 
   exec: (client, msg, args) => {
     let user = msg.member,
@@ -9,21 +9,33 @@ module.exports = {
         .get(user.id)
         .dynamicAvatarURL('png', 2048)
         .split('?')[0];
-    msg.channel.createWebhook({ name: user.username }).then(
+    msg.channel.getWebhooks().then(
       thing => {
-        setTimeout(() => {
-          client.executeWebhook(thing.id, thing.token, {
-            content: `I don't know how to spell \`embarrass\` properly.`,
-            avatarURL: avatarURL,
-            username: user.nick ? user.nick : user.username
-          });
-          setTimeout(() => {
-            client.deleteWebhook(thing.id);
-          }, 5000);
-        }, 100);
-      },
-      () => {}
-    );
+        if (
+          !thing.length ||
+          !thing.find(t => t.type === 1)
+        ) {
+          msg.channel.createWebhook({ name: 'Dad bot' }).then(
+            webhook => {
+              client
+                .executeWebhook(webhook.id, webhook.token, {
+                  content: `I don't know how to spell \`embarrass\` properly.`,
+                  username: user.nick || user.username,
+                  avatarURL
+                }).catch(() => {});
+            }
+          ).catch(() => {});
+        } else {
+          const webhook = thing.find(wh => wh.type === 1);
+          client
+            .executeWebhook(webhook.id, webhook.token, {
+              content: `I don't know how to spell \`embarrass\` properly.`,
+              username: user.nick || user.username,
+              avatarURL
+            }).catch(() => {});
+        }
+      }
+    ).catch(() => {});
   },
 
   options: {

--- a/cmds/misspelledembarrass.js
+++ b/cmds/misspelledembarrass.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'aem',
+  name: 'embarass',
 
   exec: (client, msg, args) => {
     let user = msg.member,

--- a/functions/getOrCreateWebhook.js
+++ b/functions/getOrCreateWebhook.js
@@ -1,0 +1,27 @@
+module.exports = (client, msg, deleteWh = true) => {
+  return new Promise((resolve, reject) => {
+    msg.channel.getWebhooks().then(
+      thing => {
+        if (
+          !thing.length ||
+          !thing.find(t => t.type === 1)
+        ) {
+          msg.channel.createWebhook({ name: 'Dad Bot' }).then(
+            webhook => {
+              resolve(webhook);
+
+              if (deleteWh) {
+                setTimeout(() => {
+                  client.deleteWebhook(webhook.id).catch(() => {});
+                }, 1.8e6);
+              }
+            })
+            .catch(reject);
+        } else {
+          const webhook = thing.find(wh => wh.type === 1);
+          resolve(webhook);
+        }
+      }
+    ).catch(reject);
+  });
+}


### PR DESCRIPTION
Discord allows 25 webhook creations per hour per server. With the current code, this would allow the `embarrass` command to be run 25 times before becoming unusable for an hour, as well as not allowing any other server members to create webhooks.

I've changed it so it'll only create a webhook if none exist in the current channel and it will not delete the webhook after using it.