### PR TITLE
Update depreciated package

### DIFF
--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,8 +1,7 @@
 'use strict';
 
-let DBL = require('dblapi.js');
-const dbl = new DBL(process.env.dblToken, {});
-
+let DBL = require('@top-gg/sdk');
+const api = new DBL.Api(process.env.dblToken)
 module.exports = {
   name: 'guildCreate',
 
@@ -25,38 +24,36 @@ module.exports = {
             )
           },
           author: {
-            name: `${
-              client.users.get(guild.ownerID)
-                ? client.users.get(guild.ownerID).username
-                : 'Not Cached'
-            }#${
-              client.users.get(guild.ownerID)
+            name: `${client.users.get(guild.ownerID)
+              ? client.users.get(guild.ownerID).username
+              : 'Not Cached'
+              }#${client.users.get(guild.ownerID)
                 ? client.users.get(guild.ownerID).discriminator
                 : '0000'
-            }`,
+              }`,
             icon_url: client.users.get(guild.ownerID)
               ? client.users
-                  .get(guild.ownerID)
-                  .dynamicAvatarURL(
-                    client.users.get(guild.ownerID).avatar
-                      ? client.users.get(guild.ownerID).avatar.startsWith('a_')
-                        ? 'gif'
-                        : 'png'
-                      : 'png',
-                    256
-                  )
+                .get(guild.ownerID)
+                .dynamicAvatarURL(
+                  client.users.get(guild.ownerID).avatar
+                    ? client.users.get(guild.ownerID).avatar.startsWith('a_')
+                      ? 'gif'
+                      : 'png'
+                    : 'png',
+                  256
+                )
               : client.user.defaultAvatarURL,
             url: client.users.get(guild.ownerID)
               ? client.users
-                  .get(guild.ownerID)
-                  .dynamicAvatarURL(
-                    client.users.get(guild.ownerID).avatar
-                      ? client.users.get(guild.ownerID).avatar.startsWith('a_')
-                        ? 'gif'
-                        : 'png'
-                      : 'png',
-                    256
-                  )
+                .get(guild.ownerID)
+                .dynamicAvatarURL(
+                  client.users.get(guild.ownerID).avatar
+                    ? client.users.get(guild.ownerID).avatar.startsWith('a_')
+                      ? 'gif'
+                      : 'png'
+                    : 'png',
+                  256
+                )
               : client.user.defaultAvatarURL
           },
           fields: [
@@ -103,10 +100,12 @@ module.exports = {
         }
       ]
     });
-    dbl.postStats(
-      client.guilds.filter(g => g.shard.id === guild.shard.id).length,
-      guild.shard.id,
-      Number(process.env.totalShards)
-    );
+    setInterval(() => {
+      api.postStats({
+        serverCount: client.guilds.filter(g => g.shard.id === guild.shard.id).length,
+        shardCount: Number(process.env.totalShards)
+      })
+
+    }, 2100000);
   }
 };

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,7 +1,7 @@
 'use strict';
 
-let DBL = require('dblapi.js');
-const dbl = new DBL(process.env.dblToken, {});
+let DBL = require('@top-gg/sdk');
+const api = new DBL.Api(process.env.dblToken)
 
 module.exports = {
   name: 'guildDelete',
@@ -25,38 +25,36 @@ module.exports = {
             )
           },
           author: {
-            name: `${
-              client.users.get(guild.ownerID)
-                ? client.users.get(guild.ownerID).username
-                : 'Not Cached'
-            }#${
-              client.users.get(guild.ownerID)
+            name: `${client.users.get(guild.ownerID)
+              ? client.users.get(guild.ownerID).username
+              : 'Not Cached'
+              }#${client.users.get(guild.ownerID)
                 ? client.users.get(guild.ownerID).discriminator
                 : '0000'
-            }`,
+              }`,
             icon_url: client.users.get(guild.ownerID)
               ? client.users
-                  .get(guild.ownerID)
-                  .dynamicAvatarURL(
-                    client.users.get(guild.ownerID).avatar
-                      ? client.users.get(guild.ownerID).avatar.startsWith('a_')
-                        ? 'gif'
-                        : 'png'
-                      : 'png',
-                    256
-                  )
+                .get(guild.ownerID)
+                .dynamicAvatarURL(
+                  client.users.get(guild.ownerID).avatar
+                    ? client.users.get(guild.ownerID).avatar.startsWith('a_')
+                      ? 'gif'
+                      : 'png'
+                    : 'png',
+                  256
+                )
               : client.user.defaultAvatarURL,
             url: client.users.get(guild.ownerID)
               ? client.users
-                  .get(guild.ownerID)
-                  .dynamicAvatarURL(
-                    client.users.get(guild.ownerID).avatar
-                      ? client.users.get(guild.ownerID).avatar.startsWith('a_')
-                        ? 'gif'
-                        : 'png'
-                      : 'png',
-                    256
-                  )
+                .get(guild.ownerID)
+                .dynamicAvatarURL(
+                  client.users.get(guild.ownerID).avatar
+                    ? client.users.get(guild.ownerID).avatar.startsWith('a_')
+                      ? 'gif'
+                      : 'png'
+                    : 'png',
+                  256
+                )
               : client.user.defaultAvatarURL
           },
           fields: [
@@ -103,10 +101,12 @@ module.exports = {
         }
       ]
     });
-    dbl.postStats(
-      client.guilds.filter(g => g.shard.id === guild.shard.id).length,
-      guild.shard.id,
-      Number(process.env.totalShards)
-    );
+    setInterval(() => {
+      api.postStats({
+        serverCount: client.guilds.filter(g => g.shard.id === guild.shard.id).length,
+        shardCount: Number(process.env.totalShards)
+      })
+
+    }, 2100000);
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "dependencies": {
         "@sentry/node": "^5.29.1",
+        "@top-gg/sdk": "^3.0.9",
         "chalk": "^4.1.0",
         "collections": "^5.1.12",
         "dblapi.js": "^2.4.1",
@@ -120,6 +121,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@top-gg/sdk": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@top-gg/sdk/-/sdk-3.0.9.tgz",
+      "integrity": "sha512-AskJQk6+89lIGu6UzjsDxXe4wRuc9lbpXwftIzzng2+kB8R3ZzN7hwa1nC/AacLG07m0gbBwQBWlE5IgexA/kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "raw-body": "^2.4.1"
+      }
+    },
+    "node_modules/@top-gg/sdk/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@top-gg/sdk/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/@top-gg/sdk/node_modules/raw-body": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@types/node": {
@@ -486,8 +530,6 @@
       "resolved": "https://registry.npmjs.org/eris/-/eris-0.14.0.tgz",
       "integrity": "sha512-/W6X0SFR2swtA9oc4ga5Wh1TQcZtPgbUaDDdwYc67fvFUAtwC+V1xzWUZq2yDeJnTfB8Uot9SJWA8Lthe2sDtQ==",
       "dependencies": {
-        "opusscript": "^0.0.7",
-        "tweetnacl": "^1.0.1",
         "ws": "^7.2.1"
       },
       "engines": {
@@ -1776,6 +1818,45 @@
       "requires": {
         "@sentry/types": "5.29.2",
         "tslib": "^1.9.3"
+      }
+    },
+    "@top-gg/sdk": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@top-gg/sdk/-/sdk-3.0.9.tgz",
+      "integrity": "sha512-AskJQk6+89lIGu6UzjsDxXe4wRuc9lbpXwftIzzng2+kB8R3ZzN7hwa1nC/AacLG07m0gbBwQBWlE5IgexA/kg==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "raw-body": "^2.4.1"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "raw-body": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+          "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.3",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        }
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "AlekEagle",
   "dependencies": {
     "@sentry/node": "^5.29.1",
+    "@top-gg/sdk": "^3.0.9",
     "chalk": "^4.1.0",
     "collections": "^5.1.12",
     "dblapi.js": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@top-gg/sdk": "^3.0.9",
     "chalk": "^4.1.0",
     "collections": "^5.1.12",
-    "dblapi.js": "^2.4.1",
     "dotenv": "^8.2.0",
     "eris": "^0.14.0",
     "eris-command-handler": "^1.2.1",


### PR DESCRIPTION
dblapi.js has been depreciated according to the NPM package repository, so I switched DBLapi.js to use the new package, top-gg/nodesdk